### PR TITLE
Improve dashboard with dark SaaS style

### DIFF
--- a/churn_project/churn_dashboard/prediccion/templates/home.html
+++ b/churn_project/churn_dashboard/prediccion/templates/home.html
@@ -1,41 +1,50 @@
-{% load static %}  <!-- Carga el sistema de archivos estáticos de Django -->
-
+{% load static %}
 <!DOCTYPE html>
 <html lang="es">
 <head>
-    <meta charset="UTF-8"> <!-- Define la codificación del documento -->
-    <title>Predicción de Fuga de Clientes</title> <!-- Título del navegador -->
-
-    <!-- Conexión al archivo de estilos ubicado en static/prediccion/styles.css -->
-<link rel="stylesheet" href="{% static 'prediccion/styles.css' %}">
-
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard de Fuga de Clientes</title>
+    <link rel="stylesheet" href="{% static 'prediccion/styles.css' %}">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
 <body>
-    <!-- Título principal de la página -->
-    <h1>Subí tu archivo CSV para predecir la fuga de clientes</h1>
-
-    <!-- Formulario para subir el archivo -->
-    <form method="post" enctype="multipart/form-data">
-        {% csrf_token %} <!-- Token de seguridad de Django para formularios -->
-        
-        <!-- Campo para subir archivos CSV -->
-        <input type="file" name="archivo" accept=".csv" required>
-
-        <!-- Botón para enviar el formulario -->
-        <button type="submit">Predecir</button>
-    </form>
-
-    <!-- Si existen resultados renderizados en la vista -->
-    {% if resultados %}
-    <div class="resultados">
-        <h2>Resultados:</h2>
-        {{ resultados|safe }} <!-- Muestra el dataframe HTML generado -->
-    </div>
-
-    <!-- Si ocurrió un error (por ejemplo, archivo inválido o error del modelo) -->
-    {% elif error %}
-    <div class="resultados" style="background: #ffebee;">
-        <strong>{{ error }}</strong> <!-- Mensaje de error visible para el usuario -->
-    </div>
-    {% endif %}
+<div class="dashboard">
+    <aside class="sidebar">
+        <div class="logo">Churn<span>AI</span></div>
+        <nav>
+            <ul>
+                <li class="active"><i class="fa-solid fa-chart-line"></i><span>Dashboard</span></li>
+                <li><i class="fa-solid fa-upload"></i><span>Cargar CSV</span></li>
+                <li><i class="fa-solid fa-table"></i><span>Resultados</span></li>
+            </ul>
+        </nav>
+    </aside>
+    <main class="content">
+        <h1>Predicción de Fuga de Clientes</h1>
+        <form method="post" enctype="multipart/form-data" class="upload-form">
+            {% csrf_token %}
+            <input type="file" name="archivo" accept=".csv" required>
+            <button type="submit">Predecir</button>
+        </form>
+        <div class="cards">
+            <div class="card"><canvas id="lineChart"></canvas></div>
+            <div class="card"><canvas id="pieChart"></canvas></div>
+            <div class="card"><canvas id="barChart"></canvas></div>
+        </div>
+        {% if resultados %}
+        <div class="resultados card">
+            <h2>Resultados</h2>
+            {{ resultados|safe }}
+        </div>
+        {% elif error %}
+        <div class="resultados card error">
+            <strong>{{ error }}</strong>
+        </div>
+        {% endif %}
+    </main>
+</div>
+<script src="{% static 'prediccion/scripts.js' %}"></script>
 </body>
 </html>

--- a/churn_project/churn_dashboard/static/prediccion/scripts.js
+++ b/churn_project/churn_dashboard/static/prediccion/scripts.js
@@ -1,0 +1,55 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const lineCtx = document.getElementById('lineChart');
+    const pieCtx = document.getElementById('pieChart');
+    const barCtx = document.getElementById('barChart');
+
+    if (lineCtx) {
+        new Chart(lineCtx, {
+            type: 'line',
+            data: {
+                labels: ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun'],
+                datasets: [{
+                    label: 'Clientes activos',
+                    data: [30, 50, 40, 60, 55, 70],
+                    borderColor: '#21eac6',
+                    backgroundColor: 'rgba(33,234,198,0.1)',
+                    tension: 0.4
+                }]
+            },
+            options: {
+                responsive: true,
+                plugins: {legend: {display: false}}
+            }
+        });
+    }
+
+    if (pieCtx) {
+        new Chart(pieCtx, {
+            type: 'pie',
+            data: {
+                labels: ['Leales', 'En riesgo', 'Fuga'],
+                datasets: [{
+                    data: [60, 25, 15],
+                    backgroundColor: ['#b888ff', '#21eac6', '#007bff']
+                }]
+            },
+            options: {responsive: true}
+        });
+    }
+
+    if (barCtx) {
+        new Chart(barCtx, {
+            type: 'bar',
+            data: {
+                labels: ['Producto A', 'Producto B', 'Producto C'],
+                datasets: [{
+                    label: 'Ventas',
+                    data: [150, 200, 100],
+                    backgroundColor: '#007bff'
+                }]
+            },
+            options: {responsive: true,
+                plugins: {legend: {display: false}}}
+        });
+    }
+});

--- a/churn_project/churn_dashboard/static/prediccion/styles.css
+++ b/churn_project/churn_dashboard/static/prediccion/styles.css
@@ -1,53 +1,143 @@
-/* static/prediccion/styles.css */
-
-/* Estilos generales del cuerpo de la página */
+/* Dark SaaS Dashboard styles */
 body {
-    font-family: 'Segoe UI', sans-serif; /* Fuente moderna y legible */
-    background-color: #f4f4f4;            /* Fondo gris claro para suavidad visual */
-    display: flex;                        /* Usamos flexbox para centrar */
-    flex-direction: column;              /* Dirección vertical del contenido */
-    align-items: center;                 /* Centramos horizontalmente */
-    justify-content: center;             /* Centramos verticalmente */
-    height: 100vh;                       /* Ocupa el 100% del alto de la ventana */
-    margin: 0;                           /* Quitamos márgenes por defecto */
+    font-family: 'Inter', 'Segoe UI', sans-serif;
+    background-color: #1c1d24;
+    color: #f0f0f0;
+    margin: 0;
 }
 
-/* Estilo para el título principal */
+.dashboard {
+    display: flex;
+    min-height: 100vh;
+}
+
+.sidebar {
+    width: 240px;
+    background-color: #252630;
+    padding: 1.5rem 1rem;
+    display: flex;
+    flex-direction: column;
+}
+
+.logo {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #fff;
+    margin-bottom: 2rem;
+}
+
+.logo span {
+    color: #21eac6;
+}
+
+.sidebar ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.sidebar li {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.65rem 1rem;
+    border-radius: 8px;
+    color: #ccc;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+.sidebar li:hover,
+.sidebar li.active {
+    background-color: #383a46;
+    color: #fff;
+}
+
+.content {
+    flex: 1;
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
 h1 {
-    color: #333;                         /* Texto en gris oscuro para buena lectura */
+    margin: 0;
 }
 
-/* Estilos para el formulario */
-form {
-    background: #fff;                    /* Fondo blanco para destacarse del fondo */
-    padding: 2rem;                       /* Espaciado interno generoso */
-    border-radius: 10px;                 /* Bordes redondeados suaves */
-    box-shadow: 0 0 10px rgba(0,0,0,0.1);/* Sombra leve para efecto de elevación */
-    display: flex;                       /* Flexbox para organizar los elementos */
-    flex-direction: column;             /* Verticalmente uno debajo del otro */
-    gap: 1rem;                           /* Espacio entre los elementos */
+.upload-form {
+    background-color: #2b2c37;
+    padding: 1.5rem;
+    border-radius: 12px;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.25);
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
 }
 
-/* Estilo para el input de carga de archivo */
 input[type="file"] {
-    padding: 0.5rem;                     /* Espaciado interior para mejor apariencia */
+    color: #fff;
 }
 
-/* Estilos para el botón */
 button {
-    background-color: #4CAF50;          /* Verde tipo "Aceptar/Confirmar" */
-    color: white;                       /* Texto blanco para contraste */
-    border: none;                       /* Sin bordes por defecto */
-    padding: 0.75rem 1.5rem;            /* Espaciado interno del botón */
-    border-radius: 5px;                 /* Bordes suavemente redondeados */
-    cursor: pointer;                    /* Cursor tipo "mano" al pasar el mouse */
+    background-color: #21eac6;
+    color: #1c1d24;
+    padding: 0.5rem 1rem;
+    border: none;
+    font-weight: 600;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: transform .2s;
 }
 
-/* Estilo para el contenedor de resultados */
+button:hover {
+    transform: translateY(-2px);
+}
+
+.cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1rem;
+}
+
+.card {
+    background-color: #2b2c37;
+    border-radius: 12px;
+    padding: 1rem;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.25);
+}
+
 .resultados {
-    margin-top: 1.5rem;                 /* Separación respecto al formulario */
-    background: #e8f5e9;                /* Verde muy claro para fondo suave */
-    padding: 1rem;                      /* Espaciado interno */
-    border-radius: 5px;                 /* Bordes redondeados */
-    max-width: 600px;                   /* Ancho máximo para mantener legibilidad */
+    background-color: #2b2c37;
+    padding: 1rem;
+    border-radius: 12px;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.25);
+    overflow-x: auto;
+}
+
+.resultados.error {
+    background-color: #59355b;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+table th, table td {
+    padding: 0.5rem;
+    border-bottom: 1px solid #333;
+}
+
+@media (max-width: 768px) {
+    .sidebar {
+        display: none;
+    }
+    .content {
+        padding: 1rem;
+    }
 }


### PR DESCRIPTION
## Summary
- redesign home page with sidebar, cards and charts
- apply dark theme styles
- add Chart.js charts with sample data

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68467b0100548332b2432305d8ec91ef